### PR TITLE
configure.ac: fix --disable-static enabling static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,10 +89,11 @@ fi
 AC_MSG_CHECKING([whether to enable static build])
 AC_ARG_ENABLE([static],
 	        [AS_HELP_STRING([--enable-static],[Compile static binary])],
-		[enable_static="yes"; LDFLAGS_STATIC="-static"], [enable_static="no"])
+		[], [enable_static="no"])
 AC_MSG_RESULT([$enable_static])
 
 if test "x$enable_static" = "xyes"; then
+   LDFLAGS_STATIC="-static"
    dnl -static requires to satisfy forward-dependencies
    AC_CHECK_LIB([intl], [libintl_gettext])
 fi


### PR DESCRIPTION
Thank you for reviving dsniff. I am a downstream distro maintainer (for NixOS) and the new maintainership is an occasion for me to propose autoconf improvements which would make building dsniff on NixOS easier.

The third argument of AC_ARG_ENABLE is an action executed when the flag --enable-static or --disable static is specified with any value, not an action taken when the flag is set to true/yes. So --disable-static would enable static builds unconditionally.